### PR TITLE
Feature/aws auth fixes

### DIFF
--- a/build/build-binary.sh
+++ b/build/build-binary.sh
@@ -30,7 +30,7 @@ for p in "${PLATFORMS[@]}"; do
         final_name+='.exe'
     fi
 
-    env GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags "-X 'main.Version=$VERSION'" -o $BUILD_DIR/$final_name ../ || errorExit "Building $final_name failed"
+    env GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED=0 go build -ldflags "-X 'main.Version=$VERSION'" -o $BUILD_DIR/$final_name ../ || errorExit "Building $final_name failed"
 done
 
 echo -e "\nDone!\nThe following binaries were created in the bin/ directory:"

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 All notable changes to this Helm chart will be documented in this file.
 
+## [1.1.0] - 7th April, 2026
+* Added KEP-4412 - Pod Level Identity Support For JFrog Artifactory on GCP
+* Added support for `http_timeout_seconds` for HTTP calls
+* Fixed `secret_ttl_seconds` in configmap to be of type String
+* Removed `host` header from AWS Signed requests to Artifactory to prevent from overriding host issues on webserver
+
 ## [1.0.1] - 25th Mar, 2026
 * Added support for disabling auto-upgrade of binary through `autoUpgrade`
 * Added support for `aws_region` for `assume_role` authentication method
-* Added KEP-4412 - Pod Level Identity Support For JFrog Artifactory on GCP
 
 ## [1.0.0] - 23rd Feb, 2026
 * Allow using an existing ServiceAccount when `serviceAccount.create=false`

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this Helm chart will be documented in this file.
 ## [1.1.0] - 7th April, 2026
 * Added KEP-4412 - Pod Level Identity Support For JFrog Artifactory on GCP
 * Added support for `http_timeout_seconds` for HTTP calls
-* Fixed `secret_ttl_seconds` in configmap to be of type String
+* Fixed `secret_ttl_seconds` in configmap to handle quotes
 * Removed `host` header from AWS Signed requests to Artifactory to prevent from overriding host issues on webserver
 
 ## [1.0.1] - 25th Mar, 2026

--- a/helm/templates/configmap-provider.yaml
+++ b/helm/templates/configmap-provider.yaml
@@ -75,6 +75,12 @@ data:
       "name": "disable_provider_autoupdate",
       "value": "{{ not $.Values.autoUpgrade }}"
     },
+    {{- if .http_timeout_seconds }}
+    {
+      "name": "http_timeout_seconds",
+      "value": "{{ .http_timeout_seconds | toJson }}"
+    },
+    {{- end }}
     {{- if .aws.aws_region }}
     {
       "name": "aws_region",
@@ -111,7 +117,7 @@ data:
     },
     {
       "name": "secret_ttl_seconds",
-      "value": {{- if .aws.secret_ttl_seconds }}{{ .aws.secret_ttl_seconds | toJson }}{{ else }}"14400"{{ end }}
+      "value": {{- if .aws.secret_ttl_seconds }}"{{ .aws.secret_ttl_seconds | toJson }}"{{ else }}"14400"{{ end }}
     }
     ]
     }
@@ -130,6 +136,10 @@ data:
       value: "{{ .gcp.jfrog_oidc_provider_name }}"
     - name: disable_provider_autoupdate
       value: "{{ not $.Values.autoUpgrade }}"
+    {{- if .http_timeout_seconds }}
+    - name: http_timeout_seconds
+      value: "{{ .http_timeout_seconds }}"
+    {{- end }}
     {{- end }}
 
     {{- if eq $cloudProvider "azure" }}
@@ -148,6 +158,10 @@ data:
       value: "{{ .azure.jfrog_oidc_provider_name }}"
     - name: disable_provider_autoupdate
       value: "{{ not $.Values.autoUpgrade }}"
+    {{- if .http_timeout_seconds }}
+    - name: http_timeout_seconds
+      value: "{{ .http_timeout_seconds }}"
+    {{- end }}
     {{- end }}
     {{- end }}
 

--- a/helm/templates/configmap-provider.yaml
+++ b/helm/templates/configmap-provider.yaml
@@ -117,7 +117,7 @@ data:
     },
     {
       "name": "secret_ttl_seconds",
-      "value": {{- if .aws.secret_ttl_seconds }}"{{ .aws.secret_ttl_seconds | toJson }}"{{ else }}"14400"{{ end }}
+      "value": {{- if .aws.secret_ttl_seconds }}{{ .aws.secret_ttl_seconds | toString | quote }}{{ else }}"14400"{{ end }}
     }
     ]
     }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -67,6 +67,7 @@ additionalResources: |
 providerConfig:
   - name: jfrog-credentials-provider
     artifactoryUrl: your-org.jfrog.io
+    # http_timeout_seconds: 30
     matchImages:
       - "*.jfrog.io"
     defaultCacheDuration: 15m

--- a/internal/sign/signer.go
+++ b/internal/sign/signer.go
@@ -427,5 +427,9 @@ func SignV4a(method string, url string, service string, awsCreds AwsCredentials)
 	if err != nil {
 		return nil, err
 	}
+	// removing host only from the headers to avoid 403 Forbidden error
+	// It does exist in CanonicalSignature, Artifactory adds this themseleves so we don't need to add it
+	// specifically to the headers in the request.
+	req.Header.Del("Host")
 	return req, nil
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"jfrog-credential-provider/internal/provider"
 	"log"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -71,8 +72,13 @@ func main() {
 		return
 
 	default:
-		// Default behavior
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		httpTimeout := 30 * time.Second
+		if v := os.Getenv("http_timeout_seconds"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				httpTimeout = time.Duration(n) * time.Second
+			}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 		defer cancel()
 		provider.StartProvider(ctx, Version)
 	}


### PR DESCRIPTION
## Summary

- Added configurable `http_timeout_seconds` environment variable to allow increasing the default HTTP timeout (30s) for environments where Artifactory responses take longer. It's applicable due to a bug in Access where it only falls back to regional endpoint after trying the global endpoint thrice, whicht takes about 60 seconds. 
- Fixed `secret_ttl_seconds` not being correctly applied in the AWS configmap template (Issue #51)
- Removed the `Host` header from signed requests sent to Artifactory to prevent 403 errors — the host is still included in the SigV4a canonical signature, and Artifactory reconstructs it via `X-Amz-Region-Set` when forwarding to AWS STS. This is to avoid 403 errors on the Artifactory's webservers due to the host header being used by the web servers too. 

## Details

The HTTP timeout is set as an overall context deadline in `main.go` and applies to all HTTP calls during the provider's lifecycle (cloud provider detection, signing, token exchange, and auto-update). The default remains 30 seconds; set `http_timeout_seconds` to override. Note that individual HTTP calls are also capped by the client-level timeout of 10 seconds.

## Test Plan

- [x] Verified assumed-role, projected token auth flow works on EKS with `http_timeout_seconds` set to 120
- [x] Confirmed `secret_ttl_seconds` is correctly rendered in the configmap
- [x] Tested binary on Amazon Linux 2 and Amazon Linux 2023 (built with `CGO_ENABLED=0`)
- [x] Validated SigV4a signature headers are forwarded correctly to Artifactory