### PR TITLE
Enabling Provider logs through container stdout

### DIFF
--- a/helm/templates/configmap-provider.yaml
+++ b/helm/templates/configmap-provider.yaml
@@ -75,6 +75,10 @@ data:
       "name": "disable_provider_autoupdate",
       "value": "{{ not $.Values.autoUpgrade }}"
     },
+    {
+      "name": "log_level",
+      "value": {{ $.Values.logLevel | toJson }}
+    },
     {{- if .http_timeout_seconds }}
     {
       "name": "http_timeout_seconds",
@@ -136,6 +140,8 @@ data:
       value: "{{ .gcp.jfrog_oidc_provider_name }}"
     - name: disable_provider_autoupdate
       value: "{{ not $.Values.autoUpgrade }}"
+    - name: log_level
+      value: "{{ $.Values.logLevel }}"
     {{- if .http_timeout_seconds }}
     - name: http_timeout_seconds
       value: "{{ .http_timeout_seconds }}"
@@ -162,6 +168,8 @@ data:
       value: "{{ .azure.jfrog_oidc_provider_name }}"
     - name: disable_provider_autoupdate
       value: "{{ not $.Values.autoUpgrade }}"
+    - name: log_level
+      value: "{{ $.Values.logLevel }}"
     {{- if .http_timeout_seconds }}
     - name: http_timeout_seconds
       value: "{{ .http_timeout_seconds }}"

--- a/helm/templates/configmap-setup.yaml
+++ b/helm/templates/configmap-setup.yaml
@@ -112,7 +112,7 @@ data:
     nsenter -t 1 -m -p -- systemctl status kubelet
 
     # Logs of credential provider for 30 seconds
-    nsenter -t 1 -m -p -- timeout 30s tail -n 30 -f /var/log/jfrog-credential-provider.log || true
+    nsenter -t 1 -m -p -- timeout 30s tail -n 30 -f /var/log/jfrog-credentials-provider/jfrog-credentials-provider.log || true
 
     {{- end }}
 

--- a/helm/templates/configmap-setup.yaml
+++ b/helm/templates/configmap-setup.yaml
@@ -100,9 +100,9 @@ data:
 
     log "Starting kubelet health watcher (60s)"
     {{- if or (eq $cloudProvider "gcp") (eq $cloudProvider "azure") }}
-    nsenter -t 1 -m -p -- systemd-run --scope ${JFROG_CREDENTIAL_PROVIDER_BINARY_DIR}/{{ .name }} watch-kubelet --yaml --provider-home "${KUBELET_CREDENTIAL_PROVIDER_CONFIG_DIR}" --provider-config "${KUBELET_CREDENTIAL_PROVIDER_CONFIG_FILE_NAME}" --timeout 60 &
+    nsenter -t 1 -m -p -u -- systemd-run --scope ${JFROG_CREDENTIAL_PROVIDER_BINARY_DIR}/{{ .name }} watch-kubelet --yaml --provider-home "${KUBELET_CREDENTIAL_PROVIDER_CONFIG_DIR}" --provider-config "${KUBELET_CREDENTIAL_PROVIDER_CONFIG_FILE_NAME}" --timeout 60 &
     {{- else if eq $cloudProvider "aws" }}
-    nsenter -t 1 -m -p -- systemd-run --scope ${JFROG_CREDENTIAL_PROVIDER_BINARY_DIR}/{{ .name }} watch-kubelet --provider-home "${KUBELET_CREDENTIAL_PROVIDER_CONFIG_DIR}" --provider-config "${KUBELET_CREDENTIAL_PROVIDER_CONFIG_FILE_NAME}" --timeout 60 &
+    nsenter -t 1 -m -p -u -- systemd-run --scope ${JFROG_CREDENTIAL_PROVIDER_BINARY_DIR}/{{ .name }} watch-kubelet --provider-home "${KUBELET_CREDENTIAL_PROVIDER_CONFIG_DIR}" --provider-config "${KUBELET_CREDENTIAL_PROVIDER_CONFIG_FILE_NAME}" --timeout 60 &
     {{- end }}
 
     log "Restarting the kubelet service"

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -76,9 +76,19 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       containers:
-        - name: jfrog-credential-provider-injector-pause
+        - name: jfrog-credentials-provider-main
+        {{- if .Values.containerLogging.enabled }}
+          image: {{ include "jfrog-credential-provider.initContainerImage" . }}
+          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
+          command: ["sh", "-c", "tail -F /var/log/jfrog-credentials-provider/jfrog-credentials-provider.log"]
+          volumeMounts:
+            - name: jfrog-log-dir
+              mountPath: /var/log/jfrog-credentials-provider
+              readOnly: true
+        {{- else }}
           image: {{ include "jfrog-credential-provider.pauseImage" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -109,6 +119,12 @@ spec:
         - name: {{ include "jfrog-credential-provider.fullname" . }}-config
           configMap:
             name: {{ include "jfrog-credential-provider.fullname" . }}-config
+        {{- if .Values.containerLogging.enabled }}
+        - name: jfrog-log-dir
+          hostPath:
+            path: /var/log/jfrog-credentials-provider
+            type: DirectoryOrCreate
+        {{- end }}
         {{- if .Values.customVolumes }}
         {{- .Values.customVolumes | nindent 8 }}
         {{- end }}

--- a/helm/templates/validations.yaml
+++ b/helm/templates/validations.yaml
@@ -58,3 +58,9 @@
   {{- end }}
 {{- end }}
 
+{{/* Validate logLevel is a supported value */}}
+{{- $logLevel := upper .Values.logLevel }}
+{{- if and (ne $logLevel "INFO") (ne $logLevel "DEBUG") }}
+{{- fail (printf "\nERROR: Invalid logLevel %q. Supported values are \"INFO\" or \"DEBUG\"." .Values.logLevel) }}
+{{- end }}
+

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,6 +20,16 @@ resources: {}
 # Enable automatic upgrade of the credential provider binary
 autoUpgrade: false
 
+# Log level for the credential provider binary
+# Supported values: "INFO" (default), "DEBUG"
+logLevel: "INFO"
+
+# Container logging configuration
+# When enabled, the DaemonSet main container tails the credential provider log file
+# from the host, making logs accessible via kubectl logs
+containerLogging:
+  enabled: false
+
 # Init container configuration
 initContainer:
   image:

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -43,12 +43,16 @@ func NewLogger() (*Logger, error) {
 	}
 
 	handler := slog.NewJSONHandler(logFile, &slog.HandlerOptions{
-		AddSource: true,
-		Level:     level,
+		Level: level,
 	})
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+
 	return &Logger{
-		Logger: slog.New(handler),
+		Logger: slog.New(handler).With("hostname", hostname),
 	}, nil
 }
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -15,51 +15,67 @@
 package logger
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
-const logFileLocation = "/var/log/jfrog-credential-provider.log"
-const logPrefix = "[JFROG CREDENTIALS PROVIDER] "
+const logFileLocation = "/var/log/jfrog-credentials-provider/jfrog-credentials-provider.log"
 
 type Logger struct {
-	Logger *log.Logger
+	Logger *slog.Logger
 }
 
 func NewLogger() (*Logger, error) {
+	if err := os.MkdirAll(filepath.Dir(logFileLocation), 0755); err != nil {
+		return nil, err
+	}
 	logFile, err := os.OpenFile(logFileLocation, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err
 	}
+
+	level := slog.LevelInfo
+	if strings.EqualFold(os.Getenv("log_level"), "debug") {
+		level = slog.LevelDebug
+	}
+
+	handler := slog.NewJSONHandler(logFile, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     level,
+	})
+
 	return &Logger{
-		Logger: log.New(logFile, logPrefix, log.Ldate|log.Ltime|log.Lshortfile),
+		Logger: slog.New(handler),
 	}, nil
 }
 
 func (l *Logger) Info(message interface{}) {
-	l.Logger.Println("[INFO] " + formatMessage(message))
+	l.Logger.Info(toStr(message))
 }
 
 func (l *Logger) Debug(message interface{}) {
-	l.Logger.Println("[DEBUG] " + formatMessage(message))
+	l.Logger.Debug(toStr(message))
 }
 
 func (l *Logger) Error(message interface{}) {
-	l.Logger.Println("[ERROR] " + formatMessage(message))
+	l.Logger.Error(toStr(message))
 }
 
 func (l *Logger) Exit(message interface{}, code int) {
-	l.Logger.Println("[EXIT] " + formatMessage(message))
+	l.Logger.Error(toStr(message))
 	os.Exit(code)
 }
 
-func formatMessage(message interface{}) string {
+func toStr(message interface{}) string {
 	switch v := message.(type) {
 	case string:
 		return v
 	case error:
 		return v.Error()
 	default:
-		return "unknown message type"
+		return fmt.Sprintf("%v", v)
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -34,7 +34,7 @@ import (
 const (
 	defaultSecretTTL   = "18000" // 5 hours
 	defaultHTTPTimeout = 10 * time.Second
-	logFileLocation    = "/var/log/jfrog-credential-provider.log" // "/var/log/jfrog-credential-provider.log" // used for debug: "jfrog-credential-provider.log"
+	logFileLocation    = "/var/log/jfrog-credentials-provider/jfrog-credentials-provider.log"
 	logPrefix          = "[JFROG CREDENTIALS PROVIDER] "
 )
 


### PR DESCRIPTION
Added a flag to tail logs in the main container of Daemonset. 
Changed log format to Json.
Changed log location to be under /var/log/jfrog-credentials-provider/jfrog-credentials-provider.log