### PR TITLE
fix: honor proxy env vars for provider HTTP clients

### DIFF
--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -22,7 +22,6 @@ import (
 	"jfrog-credential-provider/internal/logger"
 	"jfrog-credential-provider/internal/utils"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -251,14 +250,7 @@ func MergeConfig(dryRun, isYaml bool, providerHome string, providerConfigFileNam
 		jfrogConfigFileName = providerHome + jfrogConfigFile + ".json"
 		finalConfigFileName = providerHome + providerConfigFileName + ".json"
 	}
-	client := &http.Client{
-		Timeout: 60 * time.Second,
-		Transport: &http.Transport{
-			MaxIdleConns:       100,
-			IdleConnTimeout:    10 * time.Second,
-			DisableCompression: true,
-		},
-	}
+	client := newProviderHTTPClient(60 * time.Second)
 	svc := service.NewService(client, *logs)
 	ctx := context.Background()
 	cloudProvider := getCloudProvider(svc, ctx, logs)

--- a/internal/provider/http_client.go
+++ b/internal/provider/http_client.go
@@ -1,0 +1,33 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"net/http"
+	"time"
+)
+
+func newProviderHTTPClient(timeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.IdleConnTimeout = 10 * time.Second
+	transport.DisableCompression = true
+	transport.Proxy = http.ProxyFromEnvironment
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+}

--- a/internal/provider/http_client_test.go
+++ b/internal/provider/http_client_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewProviderHTTPClientUsesProxyFromEnvironment(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://proxy.example:8080")
+	t.Setenv("NO_PROXY", "")
+
+	client := newProviderHTTPClient(defaultHTTPTimeout)
+	if client.Timeout != defaultHTTPTimeout {
+		t.Fatalf("expected timeout %s, got %s", defaultHTTPTimeout, client.Timeout)
+	}
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://registry.example/v2/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxyURL, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://proxy.example:8080" {
+		t.Fatalf("expected proxy from HTTP_PROXY, got %v", proxyURL)
+	}
+}
+
+func TestNewProviderHTTPClientPreservesTransportSettings(t *testing.T) {
+	client := newProviderHTTPClient(60 * time.Second)
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+
+	if transport.MaxIdleConns != 100 {
+		t.Fatalf("expected MaxIdleConns 100, got %d", transport.MaxIdleConns)
+	}
+	if transport.IdleConnTimeout != 10*time.Second {
+		t.Fatalf("expected IdleConnTimeout 10s, got %s", transport.IdleConnTimeout)
+	}
+	if !transport.DisableCompression {
+		t.Fatal("expected DisableCompression to be true")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -24,7 +24,6 @@ import (
 	"jfrog-credential-provider/internal/logger"
 	"jfrog-credential-provider/internal/utils"
 	"log"
-	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -58,14 +57,7 @@ func StartProvider(ctx context.Context, Version string) {
 		secretTTL = defaultSecretTTL
 	}
 
-	client := &http.Client{
-		Timeout: defaultHTTPTimeout,
-		Transport: &http.Transport{
-			MaxIdleConns:       100,
-			IdleConnTimeout:    10 * time.Second,
-			DisableCompression: true,
-		},
-	}
+	client := newProviderHTTPClient(defaultHTTPTimeout)
 	svc := service.NewService(client, *logs)
 	// wait group for autoupdate goroutine
 	var wg sync.WaitGroup


### PR DESCRIPTION
Summary:
- Reuse a shared provider HTTP client helper for the normal provider flow and config merge flow.
- Build that client from `http.DefaultTransport.Clone()` so `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` are honored while keeping the existing timeout and transport settings.
- Add focused coverage for proxy env handling and the retained transport settings.

Verification:
- `git diff --check`
- `GOOS=linux go test -c ./internal/provider -o %TEMP%/jfrog-provider.test`
- `go test ./internal/provider` was blocked on local Windows before tests by existing Unix-only `internal/utils/lock.go` usage of `syscall.Flock`.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.

Closes #78
