### PR TITLE
feat(helm): auto-set cloud_provider env to skip cloud detection probe

### DIFF
--- a/helm/templates/configmap-provider.yaml
+++ b/helm/templates/configmap-provider.yaml
@@ -64,6 +64,10 @@ data:
   {{- if eq $cloudProvider "aws" }}
     "env": [
     {
+      "name": "cloud_provider",
+      "value": "aws"
+    },
+    {
       "name": "aws_auth_method",
       "value": {{ .aws.aws_auth_method | toJson }}
     },
@@ -147,6 +151,8 @@ data:
 
     {{- if eq $cloudProvider "gcp" }}
     env:
+    - name: cloud_provider
+      value: "google"
     - name: artifactory_url
       value: "{{ .artifactoryUrl }}"
     - name: google_service_account_email
@@ -167,6 +173,8 @@ data:
 
     {{- if eq $cloudProvider "azure" }}
     env:
+    - name: cloud_provider
+      value: "azure"
     - name: artifactory_url
       value: "{{ .artifactoryUrl }}"
     - name: azure_app_client_id


### PR DESCRIPTION
The binary's getCloudProvider() function probes AWS, Azure, and GCP metadata endpoints to detect which cloud the node runs on:

https://github.com/jfrog/jfrog-credentials-provider/blob/4f055ae08b0c0c4841830c487e9fb569be83cda9/internal/provider/provider.go#L97-L105

However, the Helm chart never sets cloud_provider in the provider config env array, even though the cloud is already known at template time (the user explicitly enables aws.enabled, gcp.enabled, or azure.enabled).
`cloudProvider := utils.GetEnvs(logs, "cloud_provider", "") `
Never sets cloudProvider because there is not ENV for it. Auto detection mechanism must always run.