### PR TITLE
feat(helm): add configurable updateStrategy for DaemonSet

### DIFF
--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "jfrog-credential-provider.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "jfrog-credential-provider.selectorLabels" . | nindent 6 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -125,6 +125,9 @@ providerConfig:
       azure_nodepool_client_id: ""
 
 
+# Update strategy for the daemonset
+updateStrategy: {}
+
 # Node selector for daemonset
 nodeSelector: {}
 


### PR DESCRIPTION
The DaemonSet currently has no updateStrategy configured, which means Kubernetes applies the default: RollingUpdate with maxUnavailable: 1. On large clusters this results in very slow rollouts (one pod at a time).

This change exposes an updateStrategy field in values.yaml, allowing operators to set e.g. maxUnavailable: 10% for faster rollouts.

The change is fully backward compatible — the default is an empty object which renders no updateStrategy block, preserving the existing behavior.