### PR TITLE
feat: Add option for "pre-baked" container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
     permissions:
       contents: write 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
-
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Import GPG Private Key
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,16 @@ jobs:
         env:
           GPG_SIGNING_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,19 +18,12 @@ jobs:
       contents: write 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.23'
+          go-version-file: 'go.mod'
 
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Build
-        env:
-          VERSION: ${{ github.event.inputs.tag }}
-        run: |
-          cd build/
-          make build-all
 
       - name: Import GPG Private Key
         run: |
@@ -38,20 +31,11 @@ jobs:
         env:
           GPG_SIGNING_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
-      - name: Sign Binaries
-        run: |
-          cd build/bin/
-          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --detach-sign --armor jfrog-credential-provider-linux-amd64
-          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --detach-sign --armor jfrog-credential-provider-linux-arm64
-
-      - name: Upload release artifacts
-        uses: softprops/action-gh-release@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          tag_name: ${{ github.event.inputs.tag }}
-          generate_release_notes: true
-          files: |
-            build/bin/jfrog-credential-provider-linux-amd64
-            build/bin/jfrog-credential-provider-linux-arm64
-            build/bin/jfrog-credential-provider-linux-amd64.asc
-            build/bin/jfrog-credential-provider-linux-arm64.asc
-    
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: self-hosted
     permissions:
       contents: write 
+      packages: write # Push to ghcr.io
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,33 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+# Disable release creation for now
+release:
+  disable: true
+
+builds:
+  - env: ["CGO_ENABLED=0"]
+    binary: jfrog-credential-provider
+    goos:
+      # - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+kos:
+  - base_image: releases-docker.jfrog.io/jfrog/alpine-with-tools:3.21.0
+    repositories:
+      - to-be-defined.example.com/jfrog-credential-provider
+    tags:
+      - "{{.Version}}"
+      # - latest
+
+    bare: true
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    sbom: none

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 
 before:
@@ -9,40 +10,49 @@ release:
   disable: true
 
 builds:
-  - env: ["CGO_ENABLED=0"]
+  - id: build-credential-provider
+    env:
+      - "CGO_ENABLED=0"
     binary: jfrog-credential-provider
     goos:
-      # - darwin
       - linux
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -X main.version={{ .Version }}
 
-## Ko-build doesn't work since the path of the binary is always /ko-app/jfrog-credential-provider for all 
-## architectures and the download script of the helm chart will append the suffix "-<ARCH_SUFFIX>" on the download url.
-## See /helm/templates/configmap-setup.yaml for more details.
-# kos:
-#   - base_image: releases-docker.jfrog.io/jfrog/alpine-with-tools:3.21.0
-#     repositories:
-#       - to-be-defined.example.com/jfrog-credential-provider
-#     tags:
-#       - "{{.Version}}"
-#       # - latest
+# Do not archive, upload binary only
+archives:
+  - id: archive-credential-provider
+    formats: ["binary"]
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
 
-#     # Bare uses a tag on the $KO_DOCKER_REPO without anything additional.
-#     bare: true
-#     # preserve_import_paths: false
-#     platforms:
-#       - linux/amd64
-#       - linux/arm64
-#     sbom: none
+signs:
+  - id: binary
+    artifacts: binary
+    signature: "${artifact}.asc"
+    cmd: gpg
+    args:
+      - "--batch"
+      - "--yes"
+      - "--pinentry-mode=loopback"
+      - "--passphrase-fd"
+      - "0"
+      - "--detach-sign"
+      - "--armor"
+      - "${artifact}"
+    stdin: "{{ .Env.GPG_PASSPHRASE }}"
+    ids:
+      - archive-credential-provider
+    output: true
 
 dockers_v2:
   - dockerfile: Dockerfile.goreleaser
     images:
       - to-be-defined.example.com/jfrog-credential-provider
     tags:
-      - "{{ .Version }}-SNAPSHOT"
+      - "{{ .Version }}"
       # - latest
     platforms:
       - linux/amd64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,16 +18,38 @@ builds:
       - amd64
       - arm64
 
-kos:
-  - base_image: releases-docker.jfrog.io/jfrog/alpine-with-tools:3.21.0
-    repositories:
+## Ko-build doesn't work since the path of the binary is always /ko-app/jfrog-credential-provider for all 
+## architectures and the download script of the helm chart will append the suffix "-<ARCH_SUFFIX>" on the download url.
+## See /helm/templates/configmap-setup.yaml for more details.
+# kos:
+#   - base_image: releases-docker.jfrog.io/jfrog/alpine-with-tools:3.21.0
+#     repositories:
+#       - to-be-defined.example.com/jfrog-credential-provider
+#     tags:
+#       - "{{.Version}}"
+#       # - latest
+
+#     # Bare uses a tag on the $KO_DOCKER_REPO without anything additional.
+#     bare: true
+#     # preserve_import_paths: false
+#     platforms:
+#       - linux/amd64
+#       - linux/arm64
+#     sbom: none
+
+dockers_v2:
+  - dockerfile: Dockerfile.goreleaser
+    images:
       - to-be-defined.example.com/jfrog-credential-provider
     tags:
-      - "{{.Version}}"
+      - "{{ .Version }}-SNAPSHOT"
       # - latest
-
-    bare: true
     platforms:
       - linux/amd64
       - linux/arm64
-    sbom: none
+    labels:
+      org.opencontainers.image.title: jfrog-credentials-provider
+      org.opencontainers.image.source: https://github.com/jfrog/jfrog-credentials-provider
+      org.opencontainers.image.version: v{{ .Version }}
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.licenses: Apache-2.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,10 +5,6 @@ before:
   hooks:
     - go mod tidy
 
-# Disable release creation for now
-release:
-  disable: true
-
 builds:
   - id: build-credential-provider
     env:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,5 @@
+FROM releases-docker.jfrog.io/jfrog/alpine-with-tools:3.21.0
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
+COPY $TARGETPLATFORM/jfrog-credential-provider /opt/jfrog-credential-provider-${TARGETARCH}

--- a/helm/templates/configmap-setup.yaml
+++ b/helm/templates/configmap-setup.yaml
@@ -125,7 +125,7 @@ data:
         fi
         DOWNLOAD_STATUS=0
         {{- end }}
-    elif [ -n "${JFROG_CREDENTIAL_PROVIDER_BINARY_URL}" ]; then
+    else
         # Build curl authentication arguments
         CURL_AUTH_ARGS=()
         if [ -n "${DOWNLOAD_ACCESS_TOKEN}" ]; then
@@ -163,10 +163,6 @@ data:
         curl -L -f "${CURL_AUTH_ARGS[@]}" -o ${KUBELET_MOUNT_PATH}${JFROG_CREDENTIAL_PROVIDER_BINARY_DIR}/{{ .name }} "${JFROG_CREDENTIAL_PROVIDER_BINARY_URL}"
         DOWNLOAD_STATUS=$?
         {{- end }}
-    else
-        log "Neither LOCAL_BINARY_HOST_PATH nor JFROG_CREDENTIAL_PROVIDER_BINARY_URL set; using binary from pre-baked container image"
-        cp /ko-app/jfrog-credential-provider "${KUBELET_MOUNT_PATH}${JFROG_CREDENTIAL_PROVIDER_BINARY_DIR}/jfrog-credentials-provider"
-        DOWNLOAD_STATUS=0
     fi
 
     if [[ ${DOWNLOAD_STATUS} -ne 0 ]]; then

--- a/helm/templates/configmap-setup.yaml
+++ b/helm/templates/configmap-setup.yaml
@@ -125,7 +125,7 @@ data:
         fi
         DOWNLOAD_STATUS=0
         {{- end }}
-    else
+    elif [ -n "${JFROG_CREDENTIAL_PROVIDER_BINARY_URL}" ]; then
         # Build curl authentication arguments
         CURL_AUTH_ARGS=()
         if [ -n "${DOWNLOAD_ACCESS_TOKEN}" ]; then
@@ -163,6 +163,10 @@ data:
         curl -L -f "${CURL_AUTH_ARGS[@]}" -o ${KUBELET_MOUNT_PATH}${JFROG_CREDENTIAL_PROVIDER_BINARY_DIR}/{{ .name }} "${JFROG_CREDENTIAL_PROVIDER_BINARY_URL}"
         DOWNLOAD_STATUS=$?
         {{- end }}
+    else
+        log "Neither LOCAL_BINARY_HOST_PATH nor JFROG_CREDENTIAL_PROVIDER_BINARY_URL set; using binary from pre-baked container image"
+        cp /ko-app/jfrog-credential-provider "${KUBELET_MOUNT_PATH}${JFROG_CREDENTIAL_PROVIDER_BINARY_DIR}/jfrog-credentials-provider"
+        DOWNLOAD_STATUS=0
     fi
 
     if [[ ${DOWNLOAD_STATUS} -ne 0 ]]; then

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,7 +3,8 @@
 
 # Download URL for the credential provider binary
 # The chart will automatically append the architecture suffix (-amd64 or -arm64)
-downloadUrl: "https://releases.jfrog.io/artifactory/run/jfrog-credentials-provider/1.4.0/jfrog-credential-provider-linux"
+# downloadUrl: "https://releases.jfrog.io/artifactory/run/jfrog-credentials-provider/1.4.0/jfrog-credential-provider-linux"
+downloadUrl: "file:///opt/jfrog-credential-provider"
 
 # Kubernetes distribution (optional). Omit for EKS, AKS, and GKE (default behavior).
 # Set to "openshift" for OpenShift on AWS or Azure — see OpenShift.md.


### PR DESCRIPTION
Resolves #99 .

The standard installation of the helm chart which downloads the binary at runtime from the internet did not pass our internal Security review. So I implemented this Goreleaser approach internally. I think it would make sense that this is the default behavior of the chart as the attack surface of the existing approach is quite high.

For further details, please read #99.


Maybe @RobinDuhan or @oumkale can share your thoughts? 