### PR TITLE
feat(helm): Add ability to run it in hostNetwork

### DIFF
--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         {{- include "jfrog-credential-provider.selectorLabels" . | nindent 8 }}
     spec:
       hostPID: true
+      hostNetwork: {{ .Values.hostNetwork | default false }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -194,3 +194,5 @@ serviceAccount:
   name: ""
   annotations: {}
 
+# Run the Pod in host network mode (can solve chicken-egg issue to pull the CNI container images)
+hostNetwork: false


### PR DESCRIPTION
With this, we are able to pull down the container image for the CNI (Cilium, Calico, ..). Without this, the credential-provider cannot start until the CNI is ready. In this case you will see the following error message:
> network is not ready: container runtime network not ready: NetworkReady=false
> reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized